### PR TITLE
add usage of exception message as record message in Logger

### DIFF
--- a/src/Logger.php
+++ b/src/Logger.php
@@ -43,7 +43,7 @@ class Logger implements ILogger
 
 		if ($message instanceof Throwable) {
 			$context['exception'] = $message;
-			$message = '';
+			$message = $message->getMessage();
 		}
 
 		$this->monolog->addRecord(


### PR DESCRIPTION
Fixes empty record message when logging exception. Uses exception message instead of empty string. Possibly resolves #1 