### PR TITLE
Update compatibility for Monolog 2 & Nette 3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,12 +12,12 @@
 		"issues": "https://github.com/nextras/tracy-monolog-adapter/issues"
 	},
 	"require": {
-		"php": ">=7.0",
-		"tracy/tracy": "~2.3",
-		"monolog/monolog": "~1.9"
+		"php": ">=7.2",
+		"tracy/tracy": "~2.4",
+		"monolog/monolog": "~2.0"
 	},
 	"require-dev": {
-		"nette/di": "~2.2"
+		"nette/di": "~3.0"
 	},
 	"autoload": {
 		"psr-4": { "Nextras\\TracyMonologAdapter\\": "src/" }

--- a/src/Bridges/NetteDI/MonologExtension.php
+++ b/src/Bridges/NetteDI/MonologExtension.php
@@ -19,7 +19,7 @@ use Tracy\Debugger;
 
 class MonologExtension extends CompilerExtension
 {
-	public function loadConfiguration()
+	public function loadConfiguration(): void
 	{
 		$builder = $this->getContainerBuilder();
 		$logDir = isset($builder->parameters['logDir']) ? Helpers::expand('%logDir%', $builder->parameters) : Debugger::$logDirectory;
@@ -58,7 +58,7 @@ class MonologExtension extends CompilerExtension
 	}
 
 
-	public function afterCompile(ClassType $class)
+	public function afterCompile(ClassType $class): void
 	{
 		$initialize = $class->getMethod('initialize');
 		$initialize->addBody('\Tracy\Debugger::setLogger($this->getByType(\Tracy\ILogger::class));');

--- a/src/Bridges/NetteDI/MonologExtension.php
+++ b/src/Bridges/NetteDI/MonologExtension.php
@@ -11,7 +11,6 @@ use Monolog\Handler\RotatingFileHandler;
 use Monolog\Logger as MonologLogger;
 use Nette\DI\CompilerExtension;
 use Nette\DI\Helpers;
-use Nette\DI\Statement;
 use Nette\PhpGenerator\ClassType;
 use Nextras\TracyMonologAdapter\Logger;
 use Nextras\TracyMonologAdapter\Processors\TracyExceptionProcessor;

--- a/src/Logger.php
+++ b/src/Logger.php
@@ -16,7 +16,7 @@ use Tracy\ILogger;
 class Logger implements ILogger
 {
 	/** @const Tracy priority to Monolog priority mapping */
-	const PRIORITY_MAP = [
+	protected const PRIORITY_MAP = [
 		self::DEBUG => Monolog\Logger::DEBUG,
 		self::INFO => Monolog\Logger::INFO,
 		self::WARNING => Monolog\Logger::WARNING,

--- a/src/Logger.php
+++ b/src/Logger.php
@@ -35,7 +35,7 @@ class Logger implements ILogger
 	}
 
 
-	public function log($message, $priority = self::INFO)
+	public function log($message, $priority = self::INFO) :void
 	{
 		$context = [
 			'at' => Helpers::getSource(),

--- a/src/Processors/TracyExceptionProcessor.php
+++ b/src/Processors/TracyExceptionProcessor.php
@@ -28,7 +28,7 @@ class TracyExceptionProcessor
 	}
 
 
-	public function __invoke(array $record)
+	public function __invoke(array $record): array
 	{
 		foreach (['exception', 'error'] as $key) {
 			if (isset($record['context'][$key]) && $record['context'][$key] instanceof Throwable) {


### PR DESCRIPTION
Package is not needed any update in code because it's mot matching any of BC break between deps versions.

## Updated packages:
- Monolog from v1.9 to v2
- Nette\DI from v2.2 to v 3
- Tracy v2.3 to v2.4

Update Tracy it's not just update, but fix, because `\Nextras\TracyMonologAdapter\Processors\TracyExceptionProcessor::logException()` is using `\Throwable`, but Tracy v2.3 knowns only `\Exception`.

Compatibility checked with `--prefer-lowest` flag too.
